### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,9 @@ migration will add any new tables or columns (it avoids dropping anything for
 safety), and you can have the cli run it directly or write it to a file.
 
 After our additions to `schema.graphql`, `gestalt migrate` will ask to confirm
-our database url, and then generate and print the following SQL migration:
+our database url (you might need to set the correct username and password to
+your database like this `'postgres://username:password@localhost/blogs'`),
+and then generate and print the following SQL migration:
 
 ```SQL
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";


### PR DESCRIPTION
Hi,

I'm new to Postgres and struggled a little bit in this step, because I needed to set my username/password here. Maybe `gestalt` could generate a better error message as well? Currently you get this error, if your username and password are wrong:

```
$ gestalt migrate
migrating..
prompt: what is the url to your database?:  (postgres://localhost/blogs) 
/usr/local/lib/node_modules/gestalt-cli/node_modules/gestalt-postgres/lib/DB.js:86
          client.query(query, escapes, function (err, result) {
                ^

TypeError: Cannot read property 'query' of null
    at /usr/local/lib/node_modules/gestalt-cli/node_modules/gestalt-postgres/lib/DB.js:86:17
```